### PR TITLE
Fix error

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -133,7 +133,7 @@ function install_files() {
   local exclude_paths exclude_file
 
   if [ ! -L "$printer_config/AFC_menu.conf" ]; then
-    ln -s "$afc_klipperscreen_path/Klipperscreen/AFC_menu.conf" "$printer_config/AFC_menu.conf"
+    ln -s "$afc_klipperscreen_path/KlipperScreen/AFC_menu.conf" "$printer_config/AFC_menu.conf"
   fi
   if [ ! -L "$klipperscreen_dir/panels/AFC.py" ]; then
     ln -s "$afc_klipperscreen_path/KlipperScreen/AFC.py" "$klipperscreen_dir/panels/AFC.py"


### PR DESCRIPTION
This pull request includes a small but critical fix in the `install.sh` script to correct a directory name in symbolic link creation.

* [`install.sh`](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fL136-R136): Updated the directory name from `Klipperscreen` to `KlipperScreen` in two symbolic link paths to ensure compatibility with the correct file structure.