### PR TITLE
Add moonraker info

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,16 +53,22 @@ If you have a custom installation of KlipperScreen or prefer to install the add-
 - The following data should be added to your `KlipperScreen.conf` file:
 ```ini
 [include AFC_menu.conf]
+```
 
-[menu __main AFC_status]
-name: AFC
-panel: boxturtle
-icon: boxturtle
+### Moonraker Update Manager
 
-[menu __print Print_AFC_status]
-name: AFC
-panel: boxturtle
-icon: boxturtle
+If you are using the Moonraker Update Manager, you can add the following to your `moonraker.conf` file:
+
+```ini
+[update_manager afc-klipperscreen-add-on]
+type: git_repo
+path: ~/AFC-Klipper-Screen-Add-On
+origin: https://github.com/ArmoredTurtle/AFC-Klipper-Screen-Add-On.git
+managed_services: KlipperScreen
+primary_branch: main
+is_system_service: False
+info_tags:
+    desc=AFC KlipperScreen Add On
 ```
 
 # Example Images


### PR DESCRIPTION
This pull request updates the `README.md` file to include instructions for integrating the Moonraker Update Manager with the AFC KlipperScreen Add-On. It also removes outdated KlipperScreen menu configuration examples.

Documentation updates:

* Added a new section, "Moonraker Update Manager," with configuration instructions for adding the AFC KlipperScreen Add-On to the `moonraker.conf` file. This includes specifying the repository, path, managed services, and additional metadata. (`[README.mdR56-R71](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R56-R71)`)

Cleanup:

* Removed outdated examples of KlipperScreen menu configuration from the documentation. (`[README.mdR56-R71](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R56-R71)`)