### PR TITLE
Fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,7 @@ If you are using the Moonraker Update Manager, you can add the following to your
 [update_manager afc-klipperscreen-add-on]
 type: git_repo
 path: ~/AFC-Klipper-Screen-Add-On
-origin: https://github.com/ArmoredTurtle/AFC-Klipper-Screen-Add-On.git
-managed_services: KlipperScreen
 primary_branch: main
-is_system_service: False
 info_tags:
     desc=AFC KlipperScreen Add On
 ```

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ If you are using the Moonraker Update Manager, you can add the following to your
 [update_manager afc-klipperscreen-add-on]
 type: git_repo
 path: ~/AFC-Klipper-Screen-Add-On
+origin: https://github.com/ArmoredTurtle/AFC-Klipper-Screen-Add-On.git
 primary_branch: main
 info_tags:
     desc=AFC KlipperScreen Add On

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ type: git_repo
 path: ~/AFC-Klipper-Screen-Add-On
 origin: https://github.com/ArmoredTurtle/AFC-Klipper-Screen-Add-On.git
 primary_branch: main
+is_system_service: False
 info_tags:
     desc=AFC KlipperScreen Add On
 ```


### PR DESCRIPTION
This pull request updates the `README.md` file to revise the example configuration for the Moonraker Update Manager. The most notable change is the removal of the `origin` and `is_system_service` fields from the example configuration.

Changes to the Moonraker Update Manager example:

* Removed the `is_system_service` field, which was set to `False`.