### PR TITLE
Add ability to specify Git branch in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -11,12 +11,14 @@ klipperscreen_conf_file=$printer_config/KlipperScreen.conf
 afc_klipperscreen_path=$HOME/AFC-Klipper-Screen-Add-On
 test_mode=False
 min_version="v0.4.5"
+branch="main"
 
 function show_help() {
-  echo "Usage: $0 [-p <printer_config>] [-k <klipperscreen_dir>] [-h]"
+  echo "Usage: $0 [-p <printer_config>] [-k <klipperscreen_dir>] [-b <branch>] [-h]"
   echo "Options:"
-  echo "  -p <printer_config>    Path to the printer configuration directory (default: $HOME/printer_data/config)"
-  echo "  -k <klipperscreen_dir> Path to the KlipperScreen directory (default: $HOME/KlipperScreen)"
+  echo "  -p <printer_config>    Path to the printer configuration directory (default: \$HOME/printer_data/config)"
+  echo "  -k <klipperscreen_dir> Path to the KlipperScreen directory (default: \$HOME/KlipperScreen)"
+  echo "  -b <branch>            Git branch to use for AFC-Klipper-Screen-Add-On (default: main)"
   echo "  -h                     Show this help message"
 }
 
@@ -69,7 +71,7 @@ function clone_repo() {
 
   if [ ! -d "$afc_klipperscreen_path/.git" ]; then
     echo "[INFO] AFC-Klipper-Screen-Add-On not found, cloning..."
-    if git -C "$afc_klipperscreen" clone https://github.com/ArmoredTurtle/AFC-Klipper-Screen-Add-On.git "$afc_klipperscreen_base"; then
+    if git -C "$afc_klipperscreen" clone --branch "$branch" https://github.com/ArmoredTurtle/AFC-Klipper-Screen-Add-On.git "$afc_klipperscreen_base"; then
       echo "[INFO] AFC-Klipper-Screen-Add-On cloned successfully."
     else
       echo "[ERROR] Failed to clone AFC-Klipper-Screen-Add-On."
@@ -81,17 +83,18 @@ function clone_repo() {
 
     # Fetch latest changes
     git fetch origin
-
+    git checkout "$branch"
+    git pull origin "$branch"
     local local_hash remote_hash base_hash
     local_hash=$(git rev-parse HEAD)
-    remote_hash=$(git rev-parse origin/main)
-    base_hash=$(git merge-base HEAD origin/main)
+    remote_hash=$(git rev-parse origin/"$branch")
+    base_hash=$(git merge-base HEAD origin/"$branch")
 
     if [[ "$local_hash" == "$remote_hash" ]]; then
       echo "[INFO] AFC-Klipper-Screen-Add-On is up to date."
     elif [[ "$local_hash" == "$base_hash" ]]; then
       echo "[INFO] Updates found. Pulling latest changes..."
-      git pull --ff-only
+      git pull --ff-only "$branch"
     else
       echo "[WARN] Local changes detected. Skipping pull to avoid overwriting."
     fi
@@ -233,12 +236,15 @@ function uninstall() {
 }
 
 
-while getopts "p:k:uth" arg; do
+# In getopts loop
+while getopts "p:k:b:uth" arg; do
   case ${arg} in
   p)
     printer_config=$OPTARG ;;
   k)
     klipperscreen_dir=$OPTARG ;;
+  b)
+    branch=$OPTARG ;;
   u)
     uninstall=True ;;
   t)


### PR DESCRIPTION
This pull request updates the `install.sh` script to add support for specifying a Git branch when cloning or updating the `AFC-Klipper-Screen-Add-On` repository. The most important changes include adding a new `-b` option for branch specification, modifying the repository cloning and update logic to use the specified branch, and updating the help message accordingly.

### Enhancements to branch handling:

* Added a `branch` variable with a default value of `"main"` to specify the Git branch for the `AFC-Klipper-Screen-Add-On` repository. (`install.sh`, [install.shR14-R21](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fR14-R21))
* Modified the `clone_repo` function to clone the repository using the specified branch and to ensure that the correct branch is checked out and updated during subsequent operations. (`install.sh`, [[1]](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fL72-R74) [[2]](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fL84-R97)

### Updates to user interaction:

* Added a `-b` option to the `getopts` loop to allow users to specify a branch via the command line. (`install.sh`, [install.shL236-R247](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fL236-R247))
* Updated the `show_help` function to include the new `-b` option in the usage instructions and help message. (`install.sh`, [install.shR14-R21](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fR14-R21))