### PR TITLE
Fix AFC panel failing to load on KlipperScreen (apiclient → restApi)

### DIFF
--- a/KlipperScreen/AFC.py
+++ b/KlipperScreen/AFC.py
@@ -211,7 +211,7 @@ class Panel(ScreenPanel):
     def __init__(self, screen, title):
         title = title or ("AFC Status")
         super().__init__(screen, title)
-        self.apiClient = screen.apiclient
+        self.apiClient = getattr(screen, "apiclient", None) or getattr(screen, "restApi", None)
         self.lane_widgets = {}
         AFClane.theme_path = screen.theme
         logging.info(f"Theme path: {AFClane.theme_path}")


### PR DESCRIPTION
## Problem
AFC panel fails to load on KlipperScreen newer than the v0.4.7 tag:
`AttributeError: 'KlipperScreen' object has no attribute 'apiclient'` at AFC.py:214 (#24).

## Root cause
KlipperScreen renamed the screen object's Moonraker REST client attribute from `apiclient`
(its name since 2020) to `restApi` in commit 4afd4bef ("refactor: rename api layer since
klippy is incorrect", 2026-06-12), updating all in-tree callers. AFC.py:214 reaches into this
attribute from out-of-tree, so the panel works on releases up to and including the v0.4.7 tag
(2026-05-13, pre-rename) and breaks on any newer master checkout (e.g. v0.4.7-101-g6db3767a)
and current master. The method surface is unchanged — KlippyRest has post_request and
send_request either way — so only the attribute name differs.

## Re the getattr(..., None) suggestion in #24
That stops the crash but leaves the panel non-functional on restApi builds: `apiclient` no
longer exists there, so the guard always returns early and no lane/status data loads (and it
logs a misleading "printer not connected").

## Fix
    self.apiClient = getattr(screen, "apiclient", None) or getattr(screen, "restApi", None)

Resolves either name; works on the v0.4.7 tag and current master, nothing downstream changes.
Since KlipperScreen exposes no stable panel API, accepting either name defensively is the
durable fix.

## Testing
BoxTurtle (4 lanes), KlipperScreen v0.4.7-101-g6db3767a (restApi): panel loads and populates
lanes/status correctly.

Fixes #24